### PR TITLE
Reject empty values in identifier columns.

### DIFF
--- a/csr/csr.py
+++ b/csr/csr.py
@@ -8,7 +8,7 @@ class Individual(BaseModel):
     """
     Individual entity
     """
-    individual_id: str = Schema(None, identity=True)
+    individual_id: str = Schema(..., min_length=1, identity=True)
     taxonomy: Optional[str]
     gender: Optional[str]
     birth_date: Optional[date]
@@ -30,8 +30,8 @@ class Diagnosis(BaseModel):
     """
     Diagnosis entity
     """
-    diagnosis_id: str = Schema(None, identity=True)
-    individual_id: str = Schema(None, references='Individual')
+    diagnosis_id: str = Schema(..., min_length=1, identity=True)
+    individual_id: str = Schema(..., min_length=1, references='Individual')
     tumor_type: Optional[str]
     topography: Optional[str]
     treatment_protocol: Optional[str]
@@ -44,11 +44,11 @@ class Biosource(BaseModel):
     """
     Biosource entity
     """
-    biosource_id: str = Schema(None, identity=True)
+    biosource_id: str = Schema(..., min_length=1, identity=True)
     biosource_dedicated: Optional[str]
-    individual_id: str = Schema(None, references='Individual')
-    diagnosis_id: Optional[str] = Schema(None, references='Diagnosis')
-    src_biosource_id: Optional[str] = Schema(None, references='Biosource')
+    individual_id: str = Schema(..., min_length=1, references='Individual')
+    diagnosis_id: Optional[str] = Schema(None, min_length=1, references='Diagnosis')
+    src_biosource_id: Optional[str] = Schema(None, min_length=1, references='Biosource')
     tissue: Optional[str]
     biosource_date: Optional[date]
     disease_status: Optional[str]
@@ -59,9 +59,9 @@ class Biomaterial(BaseModel):
     """
     Biomaterial entity
     """
-    biomaterial_id: str = Schema(None, identity=True)
-    src_biosource_id: str = Schema(None, references='Biosource')
-    src_biomaterial_id: Optional[str] = Schema(None, references='Biomaterial')
+    biomaterial_id: str = Schema(..., min_length=1, identity=True)
+    src_biosource_id: str = Schema(..., min_length=1, references='Biosource')
+    src_biomaterial_id: Optional[str] = Schema(None, min_length=1, references='Biomaterial')
     biomaterial_date: Optional[date]
     type: Optional[str]
     library_strategy: Optional[List[str]] = []
@@ -72,7 +72,7 @@ class Study(BaseModel):
     """
     Study
     """
-    study_id: str = Schema(None, identity=True)
+    study_id: str = Schema(..., min_length=1, identity=True)
     acronym: Optional[str]
     title: Optional[str]
     datadictionary: Optional[str]
@@ -82,9 +82,9 @@ class IndividualStudy(BaseModel):
     """
     Study to individual mapping
     """
-    individual_study_id: int = Schema(None, identity=True)
-    individual_id: str = Schema(None, references='Individual')
-    study_id: str = Schema(None, references='Study')
+    individual_study_id: int = Schema(..., identity=True)
+    individual_id: str = Schema(..., min_length=1, references='Individual')
+    study_id: str = Schema(..., min_length=1, references='Study')
 
 
 SubjectEntity = Union[Individual, Diagnosis, Biosource, Biomaterial]

--- a/sources2csr/sources_reader.py
+++ b/sources2csr/sources_reader.py
@@ -109,8 +109,12 @@ class SourcesReader:
         for source_file in source_files:
             source_file_data = self.read_source_file_data(source_file)
             source_id_column = source_file_id_mapping[source_file]
+            record_number = 0
             for item in source_file_data:
+                record_number += 1
                 item_id = item[source_id_column]
+                if item_id is None or item_id == '':
+                    raise DataException(f'Empty identifier in {source_file} record number {record_number}')
                 if item_id not in entity_data:
                     entity_data[item_id] = {id_column: item_id}
             source_data[source_file] = source_file_data

--- a/test_data/input_data/CLINICAL/individual_with_empty_identifier.tsv
+++ b/test_data/input_data/CLINICAL/individual_with_empty_identifier.tsv
@@ -1,0 +1,11 @@
+individual_id	taxonomy	birth_date	gender	death_date	IC_type	IC_given_date	IC_withdrawn_date	IC_material	IC_data	IC_linking_ext	report_her_susc	report_inc_finding
+P1	Human	01-02-1993	f		yes	01-03-2017		yes	yes	NA	yes	yes
+P2	Human	02-03-1992	m		yes	10-04-2017		yes	yes	NA	yes	yes
+P3	Human	03-04-1994	f		yes	11-05-2017		yes	NA	not applicable	yes	yes
+P4	Human	04-05-1993	m		no	13-06-2017		yes	yes	NA	yes	yes
+P5	Human	05-06-1995	f		yes	05-07-2017		NA	NA	NA	yes	yes
+P6	Human	06-07-1993	m		yes	20-08-2017	14-10-2017	yes	yes	NA	yes	yes
+P7	Human	07-08-1993	f		yes	12-09-2017		yes	yes	NA	yes	yes
+P8	Human	08-09-1997	m		yes	14-10-2017		yes	NA	NA	yes	yes
+P9	Human	09-10-1993	f		yes	16-11-2017		yes	yes	NA	yes	yes
+	Human	01-01-1990	f		yes	01-12-2017		yes	yes	NA	yes	yes

--- a/test_data/input_data/config/invalid_sources_config/empty_identifier/sources_config.json
+++ b/test_data/input_data/config/invalid_sources_config/empty_identifier/sources_config.json
@@ -1,0 +1,390 @@
+{
+  "entities": {
+    "Individual": {
+      "attributes": [
+        {
+          "name": "individual_id",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv",
+              "column": "individual_id"
+            },
+            {
+              "file": "ic_withdrawal.tsv",
+              "column": "person_id"
+            }
+          ]
+        },
+        {
+          "name": "taxonomy",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv"
+            }
+          ]
+        },
+        {
+          "name": "birth_date",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv",
+              "date_format": "%d-%m-%Y"
+            }
+          ]
+        },
+        {
+          "name": "gender",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv"
+            }
+          ]
+        },
+        {
+          "name": "death_date",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv",
+              "date_format": "%d-%m-%Y"
+            }
+          ]
+        },
+        {
+          "name": "ic_type",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv",
+              "column": "IC_type"
+            }
+          ]
+        },
+        {
+          "name": "ic_given_date",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv",
+              "column": "IC_given_date",
+              "date_format": "%d-%m-%Y"
+            }
+          ]
+        },
+        {
+          "name": "ic_withdrawn_date",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv",
+              "column": "IC_withdrawn_date",
+              "date_format": "%d-%m-%Y"
+            },
+            {
+              "file": "ic_withdrawal.tsv",
+              "column": "ic_withdrawn_at"
+            }
+          ]
+        },
+        {
+          "name": "ic_material",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv",
+              "column": "IC_material"
+            }
+          ]
+        },
+        {
+          "name": "ic_data",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv",
+              "column": "IC_data"
+            }
+          ]
+        },
+        {
+          "name": "ic_linking_ext",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv",
+              "column": "IC_linking_ext"
+            }
+          ]
+        },
+        {
+          "name": "report_her_susc",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv"
+            }
+          ]
+        },
+        {
+          "name": "report_inc_findings",
+          "sources": [
+            {
+              "file": "individual_with_empty_identifier.tsv",
+              "column": "report_inc_finding"
+            }
+          ]
+        }
+      ]
+    },
+    "Diagnosis": {
+      "attributes": [
+        {
+          "name": "individual_id",
+          "sources": [
+            {
+              "file": "diagnosis.tsv"
+            }
+          ]
+        },
+        {
+          "name": "diagnosis_id",
+          "sources": [
+            {
+              "file": "diagnosis.tsv"
+            }
+          ]
+        },
+        {
+          "name": "tumor_type",
+          "sources": [
+            {
+              "file": "diagnosis.tsv"
+            }
+          ]
+        },
+        {
+          "name": "topography",
+          "sources": [
+            {
+              "file": "diagnosis.tsv"
+            }
+          ]
+        },
+        {
+          "name": "treatment_protocol",
+          "sources": [
+            {
+              "file": "diagnosis.tsv"
+            }
+          ]
+        },
+        {
+          "name": "tumor_stage",
+          "sources": [
+            {
+              "file": "diagnosis.tsv"
+            }
+          ]
+        },
+        {
+          "name": "diagnosis_date",
+          "sources": [
+            {
+              "file": "diagnosis.tsv",
+              "date_format": "%d-%m-%Y"
+            }
+          ]
+        },
+        {
+          "name": "center_treatment",
+          "sources": [
+            {
+              "file": "diagnosis.tsv"
+            }
+          ]
+        }
+      ]
+    },
+    "Biosource": {
+      "attributes": [
+        {
+          "name": "biosource_id",
+          "sources": [
+            {
+              "file": "biosource.tsv"
+            }
+          ]
+        },
+        {
+          "name": "individual_id",
+          "sources": [
+            {
+              "file": "biosource.tsv"
+            }
+          ]
+        },
+        {
+          "name": "diagnosis_id",
+          "sources": [
+            {
+              "file": "biosource.tsv"
+            }
+          ]
+        },
+        {
+          "name": "src_biosource_id",
+          "sources": [
+            {
+              "file": "biosource.tsv"
+            }
+          ]
+        },
+        {
+          "name": "biosource_dedicated",
+          "sources": [
+            {
+              "file": "biosource.tsv"
+            }
+          ]
+        },
+        {
+          "name": "tissue",
+          "sources": [
+            {
+              "file": "biosource.tsv"
+            }
+          ]
+        },
+        {
+          "name": "biosource_date",
+          "sources": [
+            {
+              "file": "biosource.tsv",
+              "date_format": "%d-%m-%Y"
+            }
+          ]
+        },
+        {
+          "name": "disease_status",
+          "sources": [
+            {
+              "file": "biosource.tsv"
+            }
+          ]
+        },
+        {
+          "name": "tumor_percentage",
+          "sources": [
+            {
+              "file": "biosource.tsv"
+            }
+          ]
+        }
+      ]
+    },
+    "Biomaterial": {
+      "attributes": [
+        {
+          "name": "biomaterial_id",
+          "sources": [
+            {
+              "file": "biomaterial.tsv"
+            }
+          ]
+        },
+        {
+          "name": "src_biosource_id",
+          "sources": [
+            {
+              "file": "biomaterial.tsv"
+            }
+          ]
+        },
+        {
+          "name": "src_biomaterial_id",
+          "sources": [
+            {
+              "file": "biomaterial.tsv"
+            }
+          ]
+        },
+        {
+          "name": "biomaterial_date",
+          "sources": [
+            {
+              "file": "biomaterial.tsv",
+              "date_format": "%d-%m-%Y"
+            }
+          ]
+        },
+        {
+          "name": "type",
+          "sources": [
+            {
+              "file": "biomaterial.tsv"
+            }
+          ]
+        }
+      ]
+    },
+    "Study": {
+      "attributes": [
+        {
+          "name": "study_id",
+          "sources": [
+            {
+              "file": "study.tsv"
+            }
+          ]
+        },
+        {
+          "name": "acronym",
+          "sources": [
+            {
+              "file": "study.tsv"
+            }
+          ]
+        },
+        {
+          "name": "title",
+          "sources": [
+            {
+              "file": "study.tsv"
+            }
+          ]
+        },
+        {
+          "name": "datadictionary",
+          "sources": [
+            {
+              "file": "study.tsv"
+            }
+          ]
+        }
+      ]
+    },
+    "IndividualStudy": {
+      "attributes": [
+        {
+          "name": "individual_study_id",
+          "sources": [
+            {
+              "file": "individual_study.tsv"
+            }
+          ]
+        },
+        {
+          "name": "individual_id",
+          "sources": [
+            {
+              "file": "individual_study.tsv"
+            }
+          ]
+        },
+        {
+          "name": "study_id",
+          "sources": [
+            {
+              "file": "individual_study.tsv"
+            }
+          ]
+        }
+      ]
+    }
+  },
+  "codebooks": {
+    "individual_with_empty_identifier.tsv": "codebook.txt"
+  }
+}

--- a/tests/sources2csr/test_sources2csr.py
+++ b/tests/sources2csr/test_sources2csr.py
@@ -3,12 +3,15 @@
 
 """Tests for the sources2csr application.
 """
+import pytest
 from click.testing import CliRunner
 from os import path
 
+from csr.exceptions import DataException
 from csr.tsv_reader import TsvReader
 
 from sources2csr import sources2csr
+from sources2csr.sources_reader import SourcesReader
 
 
 def test_transformation(tmp_path):
@@ -44,3 +47,14 @@ def test_transformation(tmp_path):
     # check if data from higher priority files are not overwritten
     p6 = [ind for ind in individual_data if ind['individual_id'] == 'P6'][0]
     assert p6['ic_withdrawn_date'] == '2017-10-14'
+
+
+def test_missing_identifier(tmp_path):
+    target_path = tmp_path.as_posix()
+    reader = SourcesReader(
+        input_dir='./test_data/input_data/CLINICAL',
+        output_dir=target_path,
+        config_dir='./test_data/input_data/config/invalid_sources_config/empty_identifier')
+    with pytest.raises(DataException) as excinfo:
+        reader.read_subject_data()
+    assert 'Empty identifier' in str(excinfo.value)


### PR DESCRIPTION
Empty string was being allowed for identifiers, which would result in failures later in the loading process.