### PR TITLE
Skip if no source records

### DIFF
--- a/sources2csr/sources_reader.py
+++ b/sources2csr/sources_reader.py
@@ -186,6 +186,8 @@ class SourcesReader:
                         if attribute.name not in entity or entity[attribute.name] is None:
                             source_records = list([record for record in source_data[source.file]
                                                    if record[source_id_column] == entity_id])
+                            if not source_records:
+                                continue
                             if len(source_records) > 1:
                                 raise DataException(f'Multiple records for {entity_type.__name__}'
                                                     f' with id {entity_id} in file {source.file}')


### PR DESCRIPTION
Makes the loop skip the current source_records if it is an empty list.

If this is not done, `value` will be the `value` from the previous iteration, which could also be undefined, resulting in a `local variable 'value' referenced before assignment` error.