### PR TITLE
Do not add subject dimension tag to study registry entities

### DIFF
--- a/tests/csr2transmart/test_csr_mapper.py
+++ b/tests/csr2transmart/test_csr_mapper.py
@@ -98,7 +98,7 @@ def test_ontology_mapping(mapped_data_collection):
     assert ontology[0].children[3].children[0].concept.concept_code == 'Biomaterial.src_biomaterial_id'
     assert ontology[0].children[3].children[0].metadata.values['subject_dimension'] == 'Biomaterial'
     assert ontology[0].children[4].children[0].concept.concept_code == 'Study.study_id'
-    assert ontology[0].children[4].children[0].metadata.values['subject_dimension'] == 'Study'
+    assert ontology[0].children[4].children[0].metadata is None
 
 
 def test_observations_mapping(mapped_data_collection):


### PR DESCRIPTION
Fixes https://github.com/thehyve/python_csr2transmart/issues/53

Related ticket: [TMT-1036](https://jira.thehyve.nl/browse/TMT-1036)

To fix data already loaded to tranSMART database:
``` sql
DELETE FROM i2b2metadata.i2b2_tags WHERE tag in ('Study', 'IndividualStudy');
```