### PR TITLE
Skip uploading .seg files to cbio due to a lack of support for hg38

### DIFF
--- a/csr2cbioportal/csr2cbioportal.py
+++ b/csr2cbioportal/csr2cbioportal.py
@@ -128,8 +128,12 @@ def process_cna_files(ngs_dir: str, output_dir: str, clinical_sample_ids: List[s
         if study_file.endswith('sha1'):
             continue
 
+        # TODO to be removed after upgrade to cBioPortal version that supports hg38 for segment data
+        # For now skipping upload of .seg files, see: https://github.com/thehyve/python_csr2transmart/issues/62
+        cbioportal_seg_hg38_support = False
+
         # CNA Segment data
-        if study_file.split('.')[-1] == 'seg':
+        if study_file.split('.')[-1] == 'seg' and cbioportal_seg_hg38_support:
             logger.debug('Transforming segment data: %s' % study_file)
 
             output_file = 'data_cna_segments.seg'

--- a/tests/csr2cbioportal/test_csr2cbioportal.py
+++ b/tests/csr2cbioportal/test_csr2cbioportal.py
@@ -30,8 +30,9 @@ def test_transformation(tmp_path):
     assert path.exists(output_path + '/meta_cna_continuous.txt')
     assert path.exists(output_path + '/data_cna_discrete.txt')
     assert path.exists(output_path + '/meta_cna_discrete.txt')
-    assert path.exists(output_path + '/data_cna_segments.seg')
-    assert path.exists(output_path + '/meta_cna_segments.txt')
+    # TODO after fixing https://github.com/thehyve/python_csr2transmart/issues/62
+#     assert path.exists(output_path + '/data_cna_segments.seg')
+#     assert path.exists(output_path + '/meta_cna_segments.txt')
     assert path.exists(output_path + '/data_mutations.maf')
     assert path.exists(output_path + '/meta_mutations.txt')
     # TODO after adding more test data:


### PR DESCRIPTION
This change should be reverted after upgrade of cBioPortal version to a one that supports hg38 for segment data.

For now it will skip uploading .seg files: https://github.com/thehyve/python_csr2transmart/issues/62